### PR TITLE
Remove `--harmony` flag in node call

### DIFF
--- a/src/npmFileInclude.js
+++ b/src/npmFileInclude.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
 
 /*
 * @Author: Leander Dirkse


### PR DESCRIPTION
Removed the `--harmony` command line flag in the `#!` node call, to make it more portable. Harmony features are no longer needed in stable node versions.
